### PR TITLE
Add 10sec timeout to openssl

### DIFF
--- a/badocspcert
+++ b/badocspcert
@@ -8,7 +8,7 @@ fi
 
 TMP="$(mktemp -d)"
 
-openssl s_client -connect "$1:443" -showcerts < /dev/null &> "$TMP/_ossl.txt"
+timeout 10 openssl s_client -connect "$1:443" -showcerts < /dev/null &> "$TMP/_ossl.txt"
 
 csplit -s -f "$TMP/_pem" "$TMP/_ossl.txt" '/-----BEGIN CERTIFICATE-----/' '{*}'
 


### PR DESCRIPTION
When trying to parse URLs from a list which consists of old/non-existant or not reachable urls, openssl will hang forever. Therefore and for slower connections a 10sec timeout is very useful in our usecase, so I propose this addition here for others. Maybe not the most elegant solution but it works great.